### PR TITLE
chore(utm): override utm tags

### DIFF
--- a/composables/useUTM.ts
+++ b/composables/useUTM.ts
@@ -9,14 +9,44 @@ export const useUTM = (baseUrl: string, content: string) => {
   /**
    * Generates a URL with UTM tracking parameters
    *
-   * @returns The URL with UTM parameters
+   * @returns {string} The URL with UTM parameters
    */
   const getUrl = (): string => {
-    const url = new URL(baseUrl);
+    let url: URL;
 
-    /* Add UTM parameters */
+    try {
+      url = new URL(baseUrl);
+    } catch (error) {
+      return baseUrl;
+    }
+
+    /* Default UTM parameters */
     url.searchParams.set('utm_source', 'hawk-tracker.ru');
     url.searchParams.set('utm_content', content);
+
+    /* If current page has utm_* params, override defaults with those */
+    if (process.client && typeof window !== 'undefined') {
+      const currentSearchParams = new URLSearchParams(window.location.search || '');
+
+      /**
+       * If utm_content is overridden, we will add original button content to utm_place
+       */
+      let isUtmContentOverridden = false;
+
+      currentSearchParams.forEach((value, key) => {
+        if (key.toLowerCase().startsWith('utm_')) {
+          if (key.toLowerCase() === 'utm_content') {
+            isUtmContentOverridden = true;
+          }
+
+          url.searchParams.set(key, value);
+        }
+      });
+
+      if (isUtmContentOverridden && !url.searchParams.has('utm_place')) {
+        url.searchParams.set('utm_place', content);
+      }
+    }
 
     return url.toString();
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk-yard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "engines": {
     "node": ">=20.11.0",


### PR DESCRIPTION
1) If landing is open with utm tags, they will override existing utm tags on buttons
2) In this case, original `utm_content` will be passed as additional `utm_place` tag to save clicked button location.
3) If landing has no utm tags, default ones will be used